### PR TITLE
Add playsInline as an allowed HTML property

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -116,6 +116,7 @@ var HTMLDOMPropertyConfig = {
     optimum: 0,
     pattern: 0,
     placeholder: 0,
+    playsInline: HAS_BOOLEAN_VALUE,
     poster: 0,
     preload: 0,
     profile: 0,


### PR DESCRIPTION
This patch allows `playsInline` as an attribute.

The WHATWG has unprefixed `-webkit-playsinline` as `playsinline` (see: https://github.com/whatwg/html/pull/1444) and iOS 10 now uses it (https://webkit.org/blog/6784/new-video-policies-for-ios/).
